### PR TITLE
feat: add encryptionRequired option to openL2CAPChannel

### DIFF
--- a/android/src/main/java/com/munimbluetooth/HybridMunimBluetooth.kt
+++ b/android/src/main/java/com/munimbluetooth/HybridMunimBluetooth.kt
@@ -1056,7 +1056,7 @@ class HybridMunimBluetooth : HybridMunimBluetoothSpec() {
         }
     }
 
-    override fun openL2CAPChannel(deviceId: String, psm: Double): Promise<L2CAPChannel> {
+    override fun openL2CAPChannel(deviceId: String, psm: Double, encryptionRequired: Boolean?): Promise<L2CAPChannel> {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             return unsupportedPromise("BLE L2CAP channel streams require Android 10 or newer")
         }
@@ -1070,7 +1070,11 @@ class HybridMunimBluetooth : HybridMunimBluetoothSpec() {
 
         bluetoothScope.launch(Dispatchers.IO) {
             try {
-                val socket = device.createL2capChannel(psm.toInt())
+                val socket = if (encryptionRequired != false) {
+                    device.createL2capChannel(psm.toInt())
+                } else {
+                    device.createInsecureL2capChannel(psm.toInt())
+                }
                 socket.connect()
                 val channel = registerL2CAPSocket(socket, psm.toInt(), device.address)
                 promise.resolve(channel)

--- a/ios/HybridMunimBluetooth.swift
+++ b/ios/HybridMunimBluetooth.swift
@@ -940,7 +940,8 @@ class HybridMunimBluetooth: HybridMunimBluetoothSpec {
         publishedL2CAPPSMs.remove(psmValue)
     }
 
-    func openL2CAPChannel(deviceId: String, psm: Double) throws -> Promise<L2CAPChannel> {
+    func openL2CAPChannel(deviceId: String, psm: Double, encryptionRequired: Bool?) throws -> Promise<L2CAPChannel> {
+        // encryptionRequired is ignored on iOS — CoreBluetooth has no insecure L2CAP variant;
         let promise = Promise<L2CAPChannel>()
         guard let peripheral = connectedPeripherals[deviceId] else {
             promise.reject(withError: NSError(domain: "MunimBluetooth", code: 1, userInfo: [NSLocalizedDescriptionKey: "Device not connected"]))

--- a/nitrogen/generated/android/c++/JHybridMunimBluetoothSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridMunimBluetoothSpec.cpp
@@ -555,9 +555,10 @@ namespace margelo::nitro::munimbluetooth {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void(double /* psm */)>("unpublishL2CAPChannel");
     method(_javaPart, psm);
   }
-  std::shared_ptr<Promise<L2CAPChannel>> JHybridMunimBluetoothSpec::openL2CAPChannel(const std::string& deviceId, double psm) {
-    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* deviceId */, double /* psm */)>("openL2CAPChannel");
-    auto __result = method(_javaPart, jni::make_jstring(deviceId), psm);
+  std::shared_ptr<Promise<L2CAPChannel>> JHybridMunimBluetoothSpec::openL2CAPChannel(const std::string& deviceId, double psm, std::optional<bool> encryptionRequired) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* deviceId */, double /* psm */, jni::alias_ref<jni::JBoolean> /* encryptionRequired */)>("openL2CAPChannel");
+    auto __encryptionRequired = encryptionRequired.has_value() ? jni::autobox(static_cast<jboolean>(*encryptionRequired)) : nullptr;
+    auto __result = method(_javaPart, jni::make_jstring(deviceId), psm, __encryptionRequired);
     return [&]() {
       auto __promise = Promise<L2CAPChannel>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {

--- a/nitrogen/generated/android/c++/JHybridMunimBluetoothSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridMunimBluetoothSpec.hpp
@@ -86,7 +86,7 @@ namespace margelo::nitro::munimbluetooth {
     void stopExtendedAdvertising(const std::string& advertisingId) override;
     std::shared_ptr<Promise<L2CAPChannel>> publishL2CAPChannel(std::optional<bool> encryptionRequired) override;
     void unpublishL2CAPChannel(double psm) override;
-    std::shared_ptr<Promise<L2CAPChannel>> openL2CAPChannel(const std::string& deviceId, double psm) override;
+    std::shared_ptr<Promise<L2CAPChannel>> openL2CAPChannel(const std::string& deviceId, double psm, std::optional<bool> encryptionRequired) override;
     void closeL2CAPChannel(const std::string& channelId) override;
     std::shared_ptr<Promise<void>> sendL2CAPData(const std::string& channelId, const std::string& value) override;
     void startClassicScan() override;

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/munimbluetooth/HybridMunimBluetoothSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/munimbluetooth/HybridMunimBluetoothSpec.kt
@@ -159,7 +159,7 @@ abstract class HybridMunimBluetoothSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  abstract fun openL2CAPChannel(deviceId: String, psm: Double): Promise<L2CAPChannel>
+  abstract fun openL2CAPChannel(deviceId: String, psm: Double, encryptionRequired: Boolean?): Promise<L2CAPChannel>
   
   @DoNotStrip
   @Keep

--- a/nitrogen/generated/ios/c++/HybridMunimBluetoothSpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridMunimBluetoothSpecSwift.hpp
@@ -374,8 +374,8 @@ namespace margelo::nitro::munimbluetooth {
         std::rethrow_exception(__result.error());
       }
     }
-    inline std::shared_ptr<Promise<L2CAPChannel>> openL2CAPChannel(const std::string& deviceId, double psm) override {
-      auto __result = _swiftPart.openL2CAPChannel(deviceId, std::forward<decltype(psm)>(psm));
+    inline std::shared_ptr<Promise<L2CAPChannel>> openL2CAPChannel(const std::string& deviceId, double psm, std::optional<bool> encryptionRequired) override {
+      auto __result = _swiftPart.openL2CAPChannel(deviceId, std::forward<decltype(psm)>(psm), std::forward<decltype(encryptionRequired)>(encryptionRequired));
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }

--- a/nitrogen/generated/ios/swift/HybridMunimBluetoothSpec.swift
+++ b/nitrogen/generated/ios/swift/HybridMunimBluetoothSpec.swift
@@ -45,7 +45,7 @@ public protocol HybridMunimBluetoothSpec_protocol: HybridObject {
   func stopExtendedAdvertising(advertisingId: String) throws -> Void
   func publishL2CAPChannel(encryptionRequired: Bool?) throws -> Promise<L2CAPChannel>
   func unpublishL2CAPChannel(psm: Double) throws -> Void
-  func openL2CAPChannel(deviceId: String, psm: Double) throws -> Promise<L2CAPChannel>
+  func openL2CAPChannel(deviceId: String, psm: Double, encryptionRequired: Bool?) throws -> Promise<L2CAPChannel>
   func closeL2CAPChannel(channelId: String) throws -> Void
   func sendL2CAPData(channelId: String, value: String) throws -> Promise<Void>
   func startClassicScan() throws -> Void

--- a/nitrogen/generated/ios/swift/HybridMunimBluetoothSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridMunimBluetoothSpec_cxx.swift
@@ -678,9 +678,16 @@ open class HybridMunimBluetoothSpec_cxx {
   }
   
   @inline(__always)
-  public final func openL2CAPChannel(deviceId: std.string, psm: Double) -> bridge.Result_std__shared_ptr_Promise_L2CAPChannel___ {
+  public final func openL2CAPChannel(deviceId: std.string, psm: Double, encryptionRequired: bridge.std__optional_bool_) -> bridge.Result_std__shared_ptr_Promise_L2CAPChannel___ {
     do {
-      let __result = try self.__implementation.openL2CAPChannel(deviceId: String(deviceId), psm: psm)
+      let __result = try self.__implementation.openL2CAPChannel(deviceId: String(deviceId), psm: psm, encryptionRequired: { () -> Bool? in
+        if bridge.has_value_std__optional_bool_(encryptionRequired) {
+          let __unwrapped = bridge.get_std__optional_bool_(encryptionRequired)
+          return __unwrapped
+        } else {
+          return nil
+        }
+      }())
       let __resultCpp = { () -> bridge.std__shared_ptr_Promise_L2CAPChannel__ in
         let __promise = bridge.create_std__shared_ptr_Promise_L2CAPChannel__()
         let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_L2CAPChannel__(__promise)

--- a/nitrogen/generated/shared/c++/HybridMunimBluetoothSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridMunimBluetoothSpec.hpp
@@ -133,7 +133,7 @@ namespace margelo::nitro::munimbluetooth {
       virtual void stopExtendedAdvertising(const std::string& advertisingId) = 0;
       virtual std::shared_ptr<Promise<L2CAPChannel>> publishL2CAPChannel(std::optional<bool> encryptionRequired) = 0;
       virtual void unpublishL2CAPChannel(double psm) = 0;
-      virtual std::shared_ptr<Promise<L2CAPChannel>> openL2CAPChannel(const std::string& deviceId, double psm) = 0;
+      virtual std::shared_ptr<Promise<L2CAPChannel>> openL2CAPChannel(const std::string& deviceId, double psm, std::optional<bool> encryptionRequired) = 0;
       virtual void closeL2CAPChannel(const std::string& channelId) = 0;
       virtual std::shared_ptr<Promise<void>> sendL2CAPData(const std::string& channelId, const std::string& value) = 0;
       virtual void startClassicScan() = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -503,9 +503,10 @@ export function unpublishL2CAPChannel(psm: number): void {
  */
 export function openL2CAPChannel(
   deviceId: string,
-  psm: number
+  psm: number,
+  encryptionRequired: boolean = true
 ): Promise<L2CAPChannel> {
-  return MunimBluetooth.openL2CAPChannel(deviceId, psm)
+  return MunimBluetooth.openL2CAPChannel(deviceId, psm, encryptionRequired)
 }
 
 /**

--- a/src/specs/munim-bluetooth.nitro.ts
+++ b/src/specs/munim-bluetooth.nitro.ts
@@ -472,7 +472,7 @@ export interface MunimBluetooth
   /**
    * Open an outbound L2CAP channel to a BLE device.
    */
-  openL2CAPChannel(deviceId: string, psm: number): Promise<L2CAPChannel>
+  openL2CAPChannel(deviceId: string, psm: number, encryptionRequired?: boolean): Promise<L2CAPChannel>
 
   /**
    * Close an L2CAP channel.


### PR DESCRIPTION
Allows callers to open an insecure (unencrypted) L2CAP channel on Android without triggering a bonding/pairing prompt. Defaults to true (secure) to preserve existing behaviour.
