### PR TITLE
feat: expose Classic Bluetooth discovery metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,7 +766,7 @@ Use `addEventListener(eventName, callback)` for BLE status and data events.
 | `scanFailed` | `{ errorCode, message }` on Android scan callback failure. |
 | `advertisingStarted` | Empty payload when advertising starts. |
 | `advertisingStartFailed` | Android: `{ errorCode, message }`; iOS: `{ error }`. |
-| `classicDeviceFound` | Android Classic discovery result: `{ id, name, bondState }`. |
+| `classicDeviceFound` | Android Classic discovery result: `{ id, name, bondState, rssi?, bluetoothClass?, serviceUUIDs? }`. |
 | `classicScanFailed`, `classicScanFinished` | Android Classic discovery status events. |
 | `classicConnected`, `classicDisconnected` | Android Classic RFCOMM connection status: `{ deviceId }`. |
 | `classicConnectionReceived` | Android Classic RFCOMM inbound connection: `{ deviceId }`. |
@@ -862,6 +862,19 @@ Opens BLE L2CAP channel streams. iOS uses CoreBluetooth LE Credit Based Channels
 #### `startClassicScan()`, `connectClassic()`, `startClassicServer()`, `writeClassic()`
 
 Android Classic Bluetooth RFCOMM discovery, client connection, server listener, write, disconnect, and receive events. iOS rejects with explicit unsupported errors because public iOS APIs do not expose arbitrary Classic RFCOMM.
+
+`classicDeviceFound` includes Android classification metadata when the remote device reports it:
+
+```typescript
+addEventListener('classicDeviceFound', (device) => {
+  console.log(device.bluetoothClass?.deviceClass)
+  console.log(device.bluetoothClass?.majorDeviceClass)
+  console.log(device.bluetoothClass?.serviceClasses)
+  console.log(device.serviceUUIDs)
+})
+```
+
+`deviceClass` and `majorDeviceClass` are raw Android Bluetooth class values. `serviceClasses` contains matching `BluetoothClass.Service` bit flags. `serviceUUIDs` contains Android's cached SDP UUIDs and may be absent for unpaired or newly discovered devices. These values are classification hints; devices do not always advertise accurate class or service information.
 
 ### Types
 

--- a/android/src/main/java/com/munimbluetooth/HybridMunimBluetooth.kt
+++ b/android/src/main/java/com/munimbluetooth/HybridMunimBluetooth.kt
@@ -1,6 +1,7 @@
 package com.munimbluetooth
 
 import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothClass
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCallback
@@ -1141,14 +1142,7 @@ class HybridMunimBluetooth : HybridMunimBluetoothSpec() {
                         BluetoothDevice.ACTION_FOUND -> {
                             val device = getBluetoothDeviceExtra(intent) ?: return
                             classicDevices[device.address] = device
-                            eventEmitter.emit(
-                                "classicDeviceFound",
-                                mapOf(
-                                    "id" to device.address,
-                                    "name" to device.name,
-                                    "bondState" to bondStateFor(device).name.lowercase()
-                                )
-                            )
+                            eventEmitter.emit("classicDeviceFound", classicDevicePayload(device, intent))
                         }
 
                         BluetoothAdapter.ACTION_DISCOVERY_FINISHED -> {
@@ -2871,6 +2865,65 @@ class HybridMunimBluetooth : HybridMunimBluetoothSpec() {
         }
     }
 
+    private fun classicDevicePayload(
+        device: BluetoothDevice,
+        intent: Intent
+    ): Map<String, Any?> {
+        val payload = mutableMapOf<String, Any?>(
+            "id" to device.address,
+            "name" to device.name,
+            "bondState" to bondStateFor(device).name.lowercase()
+        )
+
+        val rssi = intent.getShortExtra(BluetoothDevice.EXTRA_RSSI, Short.MIN_VALUE)
+        if (rssi != Short.MIN_VALUE) {
+            payload["rssi"] = rssi.toInt()
+        }
+
+        getBluetoothClassExtra(intent)?.let { bluetoothClass ->
+            payload["bluetoothClass"] = mapOf(
+                "deviceClass" to bluetoothClass.deviceClass,
+                "majorDeviceClass" to bluetoothClass.majorDeviceClass,
+                "serviceClasses" to bluetoothServiceClasses(bluetoothClass)
+            )
+        }
+
+        try {
+            device.uuids
+                ?.map { it.uuid.toString() }
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { payload["serviceUUIDs"] = it }
+        } catch (error: SecurityException) {
+            Log.w(TAG, "Unable to read cached Classic Bluetooth service UUIDs", error)
+        }
+
+        return payload
+    }
+
+    private fun bluetoothServiceClasses(bluetoothClass: BluetoothClass): List<Int> {
+        val serviceClasses = CLASSIC_SERVICE_CLASSES
+            .filter { bluetoothClass.hasService(it) }
+            .toMutableList()
+
+        if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            bluetoothClass.hasService(BluetoothClass.Service.LE_AUDIO)
+        ) {
+            serviceClasses += BluetoothClass.Service.LE_AUDIO
+        }
+
+        return serviceClasses
+    }
+
+    private fun getBluetoothClassExtra(intent: Intent): BluetoothClass? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(BluetoothDevice.EXTRA_CLASS, BluetoothClass::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableExtra(BluetoothDevice.EXTRA_CLASS)
+        }
+    }
+
     private fun getBluetoothDeviceExtra(intent: Intent): BluetoothDevice? {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
@@ -2992,6 +3045,17 @@ class HybridMunimBluetooth : HybridMunimBluetoothSpec() {
             "Apple Multipeer Connectivity is only available on Apple platforms"
         private val SERIAL_PORT_PROFILE_UUID =
             UUID.fromString("00001101-0000-1000-8000-00805F9B34FB")
+        private val CLASSIC_SERVICE_CLASSES = listOf(
+            BluetoothClass.Service.LIMITED_DISCOVERABILITY,
+            BluetoothClass.Service.POSITIONING,
+            BluetoothClass.Service.NETWORKING,
+            BluetoothClass.Service.RENDER,
+            BluetoothClass.Service.CAPTURE,
+            BluetoothClass.Service.OBJECT_TRANSFER,
+            BluetoothClass.Service.AUDIO,
+            BluetoothClass.Service.TELEPHONY,
+            BluetoothClass.Service.INFORMATION
+        )
         private val CLIENT_CHARACTERISTIC_CONFIG_UUID =
             UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,27 @@ import type {
   L2CAPChannel,
 } from './specs/munim-bluetooth.nitro'
 
+/** Android Bluetooth Class of Device metadata reported during Classic discovery. */
+export interface ClassicBluetoothClass {
+  /** Raw major and minor device class bits from BluetoothClass.getDeviceClass(). */
+  deviceClass: number
+  /** Raw major device class bits from BluetoothClass.getMajorDeviceClass(). */
+  majorDeviceClass: number
+  /** Reported Android BluetoothClass.Service bit flags. */
+  serviceClasses: number[]
+}
+
+/** A device reported by Android Classic Bluetooth discovery. */
+export interface ClassicDevice {
+  id: string
+  name: string | null
+  bondState: BondState
+  rssi?: number
+  bluetoothClass?: ClassicBluetoothClass
+  /** Cached SDP UUIDs, when Android already knows them for this device. */
+  serviceUUIDs?: string[]
+}
+
 export type BluetoothEventMap = {
   deviceFound: BLEDevice
   onDeviceFound: BLEDevice
@@ -36,7 +57,7 @@ export type BluetoothEventMap = {
   scanFailed: { errorCode: number; message: string }
   advertisingStarted: Record<string, never>
   advertisingStartFailed: { error?: string; errorCode?: number; message?: string }
-  classicDeviceFound: BLEDevice & { bondState?: string }
+  classicDeviceFound: ClassicDevice
   classicScanFailed: { message: string }
   classicScanFinished: Record<string, never>
   classicConnected: { deviceId: string }


### PR DESCRIPTION
## What changed

- expose RSSI, Bluetooth class values, service-class flags, and cached SDP UUIDs on `classicDeviceFound`
- add exported `ClassicDevice` and `ClassicBluetoothClass` TypeScript interfaces
- document availability and reliability limits of Android classification metadata

## Why

Applications such as POS and label-printing clients need native hints to distinguish likely printers from unrelated Classic Bluetooth devices without relying only on device names.

## Validation

- `npm run build`
- `./gradlew :app:compileDebugKotlin` against Android API 36
- `git diff --check`
